### PR TITLE
Add core dielectric models

### DIFF
--- a/models/base_model.py
+++ b/models/base_model.py
@@ -1,0 +1,67 @@
+"""Base classes for dielectric models."""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Dict, Iterable
+
+import numpy as np
+from lmfit import Minimizer, Parameters
+
+
+class BaseModel(ABC):
+    """Abstract base class for dielectric models.
+
+    Sub-classes need to implement :meth:`epsilon` which returns the complex
+    permittivity for a set of parameters and frequencies.  The base class
+    provides a generic :meth:`residual` and :meth:`fit` implementation using
+    :mod:`lmfit`.
+    """
+
+    @abstractmethod
+    def epsilon(self, params: Dict[str, float], f_ghz: Iterable[float]) -> np.ndarray:
+        """Return complex permittivity for the model.
+
+        Parameters
+        ----------
+        params:
+            Mapping of parameter names to values.
+        f_ghz:
+            Iterable of frequencies in GHz.
+        """
+
+    def residual(self, params: Parameters, f_ghz: np.ndarray, eps_data: np.ndarray) -> np.ndarray:
+        """Residual used by :mod:`lmfit`.
+
+        Real and imaginary parts are scaled independently by their dynamic
+        range to avoid bias toward the component with the larger magnitude.
+        """
+        model_eps = self.epsilon(params.valuesdict(), f_ghz)
+        scale_real = np.max(np.abs(np.real(eps_data))) or 1.0
+        scale_imag = np.max(np.abs(np.imag(eps_data))) or 1.0
+        real_res = (np.real(model_eps) - np.real(eps_data)) / scale_real
+        imag_res = (np.imag(model_eps) - np.imag(eps_data)) / scale_imag
+        return np.concatenate([real_res, imag_res])
+
+    def fit(
+        self,
+        f_ghz: np.ndarray,
+        eps_data: np.ndarray,
+        init_params: Dict[str, float],
+    ) -> 'lmfit.model.ModelResult':
+        """Fit the model to complex permittivity data.
+
+        Parameters
+        ----------
+        f_ghz:
+            1‑D array of frequencies in GHz.
+        eps_data:
+            Complex permittivity values measured at ``f_ghz``.
+        init_params:
+            Dictionary with initial parameter guesses.
+        """
+        params = Parameters()
+        for name, value in init_params.items():
+            params.add(name, value=value, vary=True)
+
+        minimizer = Minimizer(self.residual, params, f_ghz=np.asarray(f_ghz), eps_data=np.asarray(eps_data))
+        return minimizer.minimize()

--- a/models/d_sarkar_model.py
+++ b/models/d_sarkar_model.py
@@ -1,0 +1,31 @@
+"""Djordjevic–Sarkar dielectric dispersion model."""
+from __future__ import annotations
+
+from typing import Dict, Iterable
+
+import numpy as np
+
+from .base_model import BaseModel
+
+
+class DSarkarModel(BaseModel):
+    """Implements the Djordjevic–Sarkar wideband dielectric model."""
+
+    param_names = ["eps_inf", "delta_eps", "omega1", "omega2"]
+
+    def epsilon(self, params: Dict[str, float], f_ghz: Iterable[float]) -> np.ndarray:  # type: ignore[override]
+        f_ghz = np.asarray(f_ghz)
+        omega = 2 * np.pi * f_ghz * 1e9
+        eps_inf = params["eps_inf"]
+        delta_eps = params["delta_eps"]
+        omega1 = params["omega1"]
+        omega2 = params["omega2"]
+
+        with np.errstate(divide="ignore", invalid="ignore"):
+            if omega2 <= 0 or omega1 <= 0 or omega2 <= omega1:
+                return np.full_like(f_ghz, np.nan, dtype=complex)
+            log_term = np.log((omega2**2 + omega**2) / (omega1**2 + omega**2))
+            eps_prime = eps_inf + (delta_eps / (2 * np.log(omega2 / omega1))) * log_term
+            atan_term = np.arctan(omega / omega1) - np.arctan(omega / omega2)
+            eps_double_prime = -(delta_eps / np.log(omega2 / omega1)) * atan_term
+        return eps_prime + 1j * eps_double_prime

--- a/models/havriliak_negami_model.py
+++ b/models/havriliak_negami_model.py
@@ -1,0 +1,31 @@
+"""Havriliak–Negami dielectric model."""
+from __future__ import annotations
+
+from typing import Dict, Iterable
+
+import numpy as np
+
+from .base_model import BaseModel
+
+
+class HavriliakNegamiModel(BaseModel):
+    """Implementation of the Havriliak–Negami relaxation model."""
+
+    param_names = ["eps_inf", "delta_eps", "tau", "alpha", "beta"]
+
+    def epsilon(self, params: Dict[str, float], f_ghz: Iterable[float]) -> np.ndarray:  # type: ignore[override]
+        f_ghz = np.asarray(f_ghz)
+        omega = 2 * np.pi * f_ghz * 1e9
+        eps_inf = params["eps_inf"]
+        delta_eps = params["delta_eps"]
+        tau = params["tau"]
+        alpha = params["alpha"]
+        beta = params["beta"]
+
+        with np.errstate(divide="ignore", invalid="ignore"):
+            if tau <= 0 or alpha <= 0 or alpha > 1 or beta <= 0 or beta > 1:
+                return np.full_like(f_ghz, np.nan, dtype=complex)
+            jw_tau = 1j * omega * tau
+            denominator = (1 + jw_tau ** alpha) ** beta
+            eps_complex = eps_inf + delta_eps / denominator
+        return eps_complex

--- a/models/hybrid_debye_lorentz_model.py
+++ b/models/hybrid_debye_lorentz_model.py
@@ -1,0 +1,36 @@
+"""Hybrid Debye–Lorentz model with independent Debye and Lorentz terms."""
+from __future__ import annotations
+
+from typing import Dict, Iterable
+
+import numpy as np
+
+from .base_model import BaseModel
+
+
+class HybridDebyeLorentzModel(BaseModel):
+    """Revised hybrid model combining Cole–Cole modified Debye and damped Lorentz terms."""
+
+    def __init__(self, n_terms: int):
+        self.n_terms = n_terms
+
+    def epsilon(self, params: Dict[str, float], f_ghz: Iterable[float]) -> np.ndarray:  # type: ignore[override]
+        f_ghz = np.asarray(f_ghz)
+        omega = 2 * np.pi * f_ghz * 1e9
+        eps_inf = float(params.get("eps_inf", 1.0))
+        complex_eps = np.ones_like(omega, dtype=complex) * eps_inf
+
+        for i in range(self.n_terms):
+            delta_D = float(params.get(f"delta_eps_D{i+1}", 0.0))
+            tau_D = float(params.get(f"tau_D{i+1}", 1e-9))
+            alpha = float(params.get(f"alpha{i+1}", 1.0))
+            delta_L = float(params.get(f"delta_eps_L{i+1}", 0.0))
+            omega0 = float(params.get(f"omega0{i+1}", 1e10))
+            q = float(params.get(f"q{i+1}", 0.05))
+            gamma = q * omega0
+
+            debye = delta_D / (1 + (1j * omega * tau_D) ** alpha)
+            lorentz = delta_L * omega0 ** 2 / (omega0 ** 2 - omega ** 2 - 1j * 2 * gamma * omega)
+            complex_eps += debye + lorentz
+
+        return complex_eps

--- a/models/multi_pole_debye_model.py
+++ b/models/multi_pole_debye_model.py
@@ -1,0 +1,32 @@
+"""Multi‑pole Debye relaxation model."""
+from __future__ import annotations
+
+from typing import Dict, Iterable
+
+import numpy as np
+
+from .base_model import BaseModel
+
+
+class MultiPoleDebyeModel(BaseModel):
+    """Debye model with an arbitrary number of relaxation poles."""
+
+    def __init__(self, n_poles: int):
+        self.n_poles = n_poles
+
+    def epsilon(self, params: Dict[str, float], f_ghz: Iterable[float]) -> np.ndarray:  # type: ignore[override]
+        f_ghz = np.asarray(f_ghz)
+        omega = 2 * np.pi * f_ghz * 1e9
+        eps_inf = float(params.get("eps_inf", 1.0))
+        complex_eps = np.ones_like(omega, dtype=complex) * eps_inf
+
+        for i in range(self.n_poles):
+            delta_eps = float(params.get(f"delta_eps_{i}", 0.0))
+            # Support either log_tau_i or tau_i
+            if f"log_tau_{i}" in params:
+                tau = 10 ** float(params[f"log_tau_{i}"])
+            else:
+                tau = float(params.get(f"tau_{i}", 1e-12))
+            complex_eps += delta_eps / (1 + 1j * omega * tau)
+
+        return complex_eps


### PR DESCRIPTION
## Summary
- add base model with residual scaling and lmfit fitting
- implement Djordjevic–Sarkar, Havriliak–Negami, hybrid Debye–Lorentz, and multi-pole Debye models

## Testing
- `python -m py_compile models/*.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890aaabe8c4832abe7786b85cfb563d