### PR TITLE
refactor models to use lmfit ComplexModel

### DIFF
--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,0 +1,11 @@
+from .havriliak_negami import HavriliakNegamiModel
+from .d_sarkar import DSarkarModel
+from .hybrid_debye_lorentz import HybridDebyeLorentzModel
+from .multi_pole_debye import MultiPoleDebyeModel
+
+__all__ = [
+    "HavriliakNegamiModel",
+    "DSarkarModel",
+    "HybridDebyeLorentzModel",
+    "MultiPoleDebyeModel",
+]

--- a/models/_eval_funcs.py
+++ b/models/_eval_funcs.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+import numpy as np
+import numpy.typing as npt
+
+FloatArray = npt.NDArray[np.float64]
+ComplexArray = npt.NDArray[np.complex128]
+
+_GHZ_TO_RAD_S = 2 * np.pi * 1e9
+
+
+def hn_eval(
+    f_ghz: FloatArray,
+    eps_inf: float,
+    delta_eps: float,
+    tau: float,
+    alpha: float,
+    beta: float,
+) -> ComplexArray:
+    """Havriliak–Negami permittivity in SI units internally."""
+    omega = _GHZ_TO_RAD_S * f_ghz
+    jw_tau = 1j * omega * tau
+    return eps_inf + delta_eps / (1 + jw_tau ** alpha) ** beta
+
+
+def dsarkar_eval(
+    f_ghz: FloatArray,
+    eps_inf: float,
+    delta_eps: float,
+    omega1: float,
+    omega2: float,
+) -> ComplexArray:
+    """Djordjevic–Sarkar permittivity evaluated over ``f_ghz``."""
+    omega = _GHZ_TO_RAD_S * f_ghz
+    with np.errstate(divide="ignore", invalid="ignore"):
+        log_term = np.log((omega2**2 + omega**2) / (omega1**2 + omega**2))
+        eps_prime = eps_inf + (delta_eps / (2 * np.log(omega2 / omega1))) * log_term
+        atan_term = np.arctan(omega / omega1) - np.arctan(omega / omega2)
+        eps_double_prime = -(delta_eps / np.log(omega2 / omega1)) * atan_term
+    return eps_prime + 1j * eps_double_prime
+
+
+def multi_pole_debye_eval(
+    f_ghz: FloatArray,
+    n_poles: int,
+    eps_inf: float,
+    **params: float,
+) -> ComplexArray:
+    """Multi-pole Debye model evaluation.
+
+    Parameters are expected as ``delta_eps_i`` and either ``log_tau_i`` or
+    ``tau_i`` for ``i`` in ``range(n_poles)``.
+    """
+    omega = _GHZ_TO_RAD_S * f_ghz
+    perm = np.full_like(omega, eps_inf, dtype=np.complex128)
+    for i in range(n_poles):
+        delta = params.get(f"delta_eps_{i}", 0.0)
+        if f"log_tau_{i}" in params:
+            tau = 10 ** params[f"log_tau_{i}"]
+        else:
+            tau = params.get(f"tau_{i}", 1e-12)
+        perm += delta / (1 + 1j * omega * tau)
+    return perm
+
+
+def hybrid_debye_lorentz_eval(
+    f_ghz: FloatArray,
+    n_terms: int,
+    eps_inf: float,
+    **params: float,
+) -> ComplexArray:
+    """Hybrid Debye–Lorentz model evaluation."""
+    omega = _GHZ_TO_RAD_S * f_ghz
+    eps = np.full_like(omega, eps_inf, dtype=np.complex128)
+    for i in range(n_terms):
+        j = i + 1
+        delta_D = params.get(f"delta_eps_D{j}", 0.0)
+        tau_D = params.get(f"tau_D{j}", 1e-12)
+        alpha = params.get(f"alpha{j}", 1.0)
+        delta_L = params.get(f"delta_eps_L{j}", 0.0)
+        omega0 = params.get(f"omega0{j}", 1.0)
+        q = params.get(f"q{j}", 0.0)
+        gamma = q * omega0
+        debye = delta_D / (1 + (1j * omega * tau_D) ** alpha)
+        lorentz = delta_L * omega0**2 / (
+            omega0**2 - omega**2 - 1j * 2 * gamma * omega
+        )
+        eps += debye + lorentz
+    return eps

--- a/models/_mixins.py
+++ b/models/_mixins.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+import numpy as np
+
+
+class ScaledResidualMixin:
+    """Normalise real and imag residuals by their dynamic range."""
+
+    def _residual(self, params, data, f_ghz=None, **kws):  # lmfit hook
+        model = self.eval(params, f_ghz=f_ghz, **kws)
+        scale_r = np.ptp(np.real(data)) or 1.0
+        scale_i = np.ptp(np.imag(data)) or 1.0
+        res = (np.real(model) - np.real(data)) / scale_r
+        resi = (np.imag(model) - np.imag(data)) / scale_i
+        return np.concatenate((res, resi)).ravel()

--- a/models/d_sarkar.py
+++ b/models/d_sarkar.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+import numpy.typing as npt
+from lmfit.models import ComplexModel
+
+from ._eval_funcs import dsarkar_eval
+from ._mixins import ScaledResidualMixin
+
+FloatArray = npt.NDArray
+ComplexArray = npt.NDArray
+
+
+class DSarkarModel(ScaledResidualMixin, ComplexModel):
+    """ComplexModel implementation of the Djordjevic–Sarkar dispersion."""
+
+    def __init__(self, prefix: str = "", **kws):
+        super().__init__(dsarkar_eval, independent_vars=["f_ghz"], prefix=prefix, **kws)
+        self.set_param_hint("eps_inf", min=1.0)
+        self.set_param_hint("delta_eps", min=0.0)
+        self.set_param_hint("omega1", min=1e7)
+        self.set_param_hint("omega2", expr=f"{prefix}omega1*10")
+
+    def guess(self, data: ComplexArray, f_ghz: FloatArray, **overrides):
+        eps_inf = float((data[-1]).real)
+        delta = float((data[0] - data[-1]).real)
+        omega_peak = _guess_peak(f_ghz, data)
+        params = self.make_params(
+            eps_inf=eps_inf,
+            delta_eps=delta,
+            omega1=omega_peak,
+            omega2=omega_peak * 10,
+        )
+        params.update(overrides)
+        return params
+
+
+def _guess_peak(f_ghz: FloatArray, data: ComplexArray) -> float:
+    """Estimate omega1 based on maximum loss point."""
+    import numpy as np
+
+    idx = int(np.argmax(np.imag(data)))
+    f_hz = f_ghz[idx] * 1e9
+    return 2 * np.pi * f_hz

--- a/models/havriliak_negami.py
+++ b/models/havriliak_negami.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+import numpy as np
+import numpy.typing as npt
+from lmfit.models import ComplexModel
+
+from ._eval_funcs import hn_eval
+from ._mixins import ScaledResidualMixin
+
+FloatArray = npt.NDArray[np.float64]
+ComplexArray = npt.NDArray[np.complex128]
+
+
+class HavriliakNegamiModel(ScaledResidualMixin, ComplexModel):
+    """lmfit ComplexModel wrapper for the Havriliak–Negami dispersion."""
+
+    def __init__(self, prefix: str = "", **kws):
+        super().__init__(hn_eval, independent_vars=["f_ghz"], prefix=prefix, **kws)
+        self.set_param_hint("eps_inf", value=1.0, min=1.0)
+        self.set_param_hint("delta_eps", value=1.0, min=0.0)
+        self.set_param_hint("tau", value=1e-9, min=1e-15)
+        self.set_param_hint("alpha", value=0.8, min=0.0, max=1.0)
+        self.set_param_hint("beta", value=0.8, min=0.0, max=1.0)
+
+    def guess(
+        self, data: ComplexArray, f_ghz: FloatArray, **overrides: float
+    ):
+        peak_idx = np.argmax(np.imag(data))
+        tau_guess = 1 / (2 * np.pi * f_ghz[peak_idx] * 1e9)
+        params = self.make_params(
+            eps_inf=np.real(data[-1]),
+            delta_eps=np.real(data[0]) - np.real(data[-1]),
+            tau=tau_guess,
+            alpha=0.8,
+            beta=0.8,
+        )
+        params.update(overrides)
+        return params

--- a/models/hybrid_debye_lorentz.py
+++ b/models/hybrid_debye_lorentz.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+from lmfit.models import ComplexModel
+
+from ._eval_funcs import hybrid_debye_lorentz_eval
+from ._mixins import ScaledResidualMixin
+
+
+class HybridDebyeLorentzModel(ScaledResidualMixin, ComplexModel):
+    """Hybrid model combining Debye and Lorentz mechanisms."""
+
+    def __init__(self, n_terms: int, prefix: str = "", **kws):
+        self.n_terms = n_terms
+
+        def _eval(f_ghz, eps_inf, **params):
+            return hybrid_debye_lorentz_eval(f_ghz, n_terms, eps_inf, **params)
+
+        super().__init__(_eval, independent_vars=["f_ghz"], prefix=prefix, **kws)
+
+        self.set_param_hint("eps_inf", min=1.0)
+        for i in range(1, n_terms + 1):
+            self.set_param_hint(f"delta_eps_D{i}", min=0.0)
+            self.set_param_hint(f"tau_D{i}", min=1e-15)
+            self.set_param_hint(f"alpha{i}", min=0.0, max=1.0)
+            self.set_param_hint(f"delta_eps_L{i}", min=0.0)
+            self.set_param_hint(f"omega0{i}", min=1e7)
+            self.set_param_hint(f"q{i}", min=0.0, max=1.0)

--- a/models/multi_pole_debye.py
+++ b/models/multi_pole_debye.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+from lmfit.models import ComplexModel
+
+from ._eval_funcs import multi_pole_debye_eval
+from ._mixins import ScaledResidualMixin
+
+
+class MultiPoleDebyeModel(ScaledResidualMixin, ComplexModel):
+    """Debye model with a configurable number of relaxation poles."""
+
+    def __init__(self, n_poles: int, prefix: str = "", **kws):
+        self.n_poles = n_poles
+
+        def _eval(f_ghz, eps_inf, **params):
+            return multi_pole_debye_eval(f_ghz, n_poles, eps_inf, **params)
+
+        super().__init__(_eval, independent_vars=["f_ghz"], prefix=prefix, **kws)
+
+        self.set_param_hint("eps_inf", min=1.0)
+        for i in range(n_poles):
+            self.set_param_hint(f"delta_eps_{i}", min=0.0)
+            self.set_param_hint(f"log_tau_{i}", min=-15, max=5)


### PR DESCRIPTION
## Summary
- introduce shared evaluation helpers and residual scaling mixin
- migrate Havriliak–Negami, Djordjevic–Sarkar, hybrid Debye–Lorentz, and multi‑pole Debye to lmfit ComplexModel subclasses
- expose new models via models package for composition and parameter hints

## Testing
- `python -m py_compile models/_eval_funcs.py models/_mixins.py models/havriliak_negami.py models/d_sarkar.py models/multi_pole_debye.py models/hybrid_debye_lorentz.py models/__init__.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890bcd3ba1c832a81e9cdf4bcba9b66